### PR TITLE
Add Gitpod support + do some refactoring on README

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+# Simply install Heroku CLI
+# Just in case we use Gitpod for deployment.
+RUN curl https://cli-assets.heroku.com/install.sh | -

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,3 +10,4 @@ tasks:
         bash run
       else
         echo "Please copy the config.env.sample file and edit it to continue."
+      fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  # Install dependencies first.
+  - init: pip install -r ./requirements.txt
+    # Then run if there's config.env, otherwise prompt to configure.
+    command: >
+      if [[ -f config.env ]]; then
+        bash run
+      else
+        echo "Please copy the config.env.sample file and edit it to continue."

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   * split / combine
   * gadmin
   * plugin manager
-  * etc...
+  * ...and more
 * Channel & Group log support
 * Database support
 * Build-in help support
@@ -98,25 +98,17 @@ async def test_filter(message: Message):
 
 ## How To Deploy 👷
 
-* **[HEROKU](https://www.heroku.com/) Method** 🚀
+* With Heroku:
+  > **NOTE** : your can fill other vars as your need and they are optional. (settings -> reveal config vars)
+  * First click [**this**](https://heroku.com/deploy?template=https://github.com/UsergeTeam/Userge/tree/master)
+  * Fill `API_ID`, `API_HASH`, `DATABASE_URL` and `LOG_CHANNEL_ID` (**required**)
+  * Choose your [**MODE**](https://github.com/UsergeTeam/Userge#userge-modes-)
+  * Then fill other **non-required** vars as relevent to your **MODE**
+  * Finally **hit deploy** button
 
-  > First click [**this**](https://heroku.com/deploy?template=https://github.com/UsergeTeam/Userge/tree/master)
-
-  > Fill `API_ID`, `API_HASH`, `DATABASE_URL` and `LOG_CHANNEL_ID` (**required**)
-
-  > Choose your [**MODE**](https://github.com/UsergeTeam/Userge#userge-modes-)
-
-  > Then fill other **non-required** vars as relevent to your **MODE**
-
-  > Finally **hit deploy** button
-
-  > [**NOTE**] : your can fill other vars as your need and they are optional. (settings -> reveal config vars)
-
-* **Docker Method** 🐳 
-
+* With Docker 🐳 
     - [**See Detailed Guide**](resources/radmeDocker.md)
-* **Other Method** 🔧
-
+* With Git, Python and pip 🔧
   ```bash
   # clone the repo
   git clone https://github.com/UsergeTeam/Userge.git

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ async def test_filter(message: Message):
 
 ### Support & Discussions 👥
 
-> Head over to the [Discussion Group](https://t.me/slbotsbugs) and [Update Channel](https://t.me/theUserge)
+> Head over to the [Discussion Group](https://t.me/usergeot) and [Update Channel](https://t.me/theUserge)
 
 ### Project Credits 💆‍♂️
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@
 
 # Userge 🔥
 
-[![Build Status](https://travis-ci.com/UsergeTeam/Userge.svg?branch=dev)](https://travis-ci.com/UsergeTeam/Userge) ![Python Version](https://img.shields.io/badge/python-3.8-lightgrey) ![Release](https://img.shields.io/github/v/release/UsergeTeam/Userge) ![Stars](https://img.shields.io/github/stars/UsergeTeam/Userge) ![Forks](https://img.shields.io/github/forks/UsergeTeam/Userge) ![Issues Open](https://img.shields.io/github/issues/UsergeTeam/Userge) ![Issues Closed](https://img.shields.io/github/issues-closed/UsergeTeam/Userge) ![PR Open](https://img.shields.io/github/issues-pr/UsergeTeam/Userge) ![PR Closed](https://img.shields.io/github/issues-pr-closed/UsergeTeam/Userge) ![Contributors](https://img.shields.io/github/contributors/UsergeTeam/Userge) ![Repo Size](https://img.shields.io/github/repo-size/UsergeTeam/Userge) ![License](https://img.shields.io/github/license/UsergeTeam/Userge) ![Commit Activity](https://img.shields.io/github/commit-activity/m/UsergeTeam/Userge) [![Plugins Repo!](https://img.shields.io/badge/Plugins%20Repo-!-orange)](https://github.com/UsergeTeam/Userge-Plugins) [![Join Channel!](https://img.shields.io/badge/Join%20Channel-!-red)](https://t.me/theUserge) [![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/UsergeTeam/Userge/?ref=repository-badge)
+[![Build Status](https://travis-ci.com/UsergeTeam/Userge.svg?branch=dev)](https://travis-ci.com/UsergeTeam/Userge)
+![Python Version](https://img.shields.io/badge/python-3.8-lightgrey)
+![Release](https://img.shields.io/github/v/release/UsergeTeam/Userge)
+![Stars](https://img.shields.io/github/stars/UsergeTeam/Userge)
+![Forks](https://img.shields.io/github/forks/UsergeTeam/Userge)
+![Issues Open](https://img.shields.io/github/issues/UsergeTeam/Userge)
+![Issues Closed](https://img.shields.io/github/issues-closed/UsergeTeam/Userge)
+![PRs Open](https://img.shields.io/github/issues-pr/UsergeTeam/Userge)
+![PRs Closed](https://img.shields.io/github/issues-pr-closed/UsergeTeam/Userge)
+![Contributors](https://img.shields.io/github/contributors/UsergeTeam/Userge)
+![Repo Size](https://img.shields.io/github/repo-size/UsergeTeam/Userge)
+![License](https://img.shields.io/github/license/UsergeTeam/Userge)
+![Commit Activity](https://img.shields.io/github/commit-activity/m/UsergeTeam/Userge)
+[![Plugins Repo!](https://img.shields.io/badge/Plugins%20Repo-!-orange)](https://github.com/UsergeTeam/Userge-Plugins)
+[![Join Channel!](https://img.shields.io/badge/Join%20Channel-!-red)](https://t.me/theUserge)
+[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/UsergeTeam/Userge/?ref=repository-badge)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/UsergeTeam/Userge)
 
 > **Userge** is a Powerful , _Pluggable_ Telegram UserBot written in _Python_ using [Pyrogram](https://github.com/pyrogram/pyrogram).
 


### PR DESCRIPTION
In this PR, Andrei Jiroh (me) from @MadeByThePinsHub did the following:
* add Gitpod support so users can simply try Userge first in a cloud dev environment before self-hosting or even deploying to Heroku (the CLI is pre-installed on workspace build)
* revamped/refactored the README (don't worry, `markdownlint` isn't there yet)