### PR TITLE
Bump base image Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # set base image (host OS)
-FROM python:3.8
+FROM python:3.9
 
 # set the working directory in the container
 WORKDIR /app/

--- a/config.env.sample
+++ b/config.env.sample
@@ -118,6 +118,9 @@ UNFINISHED_PROGRESS_STR='░'
 # custom name for your sticker pack
 CUSTOM_PACK_NAME=""
 
+# Deezer ARL Token Read it "https://t.me/UnofficialPluginsHelp/4"
+ARL_TOKEN=""
+
 
 # set your own custom media for .alive or
 # disable it by putting value 'nothing'


### PR DESCRIPTION
Dockerfile: `Change base image to python3.9`
Sample config: `Missing ARL_TOKEN unofficial-plugin`