### PR TITLE
A little change to fix "ERROR: No closing quotation"

### DIFF
--- a/userge/utils/tools.py
+++ b/userge/utils/tools.py
@@ -112,7 +112,7 @@ async def take_screen_shot(video_file: str, duration: int, path: str = '') -> Op
     _LOG.info('[[[Extracting a frame from %s ||| Video duration => %s]]]', video_file, duration)
     ttl = duration // 2
     thumb_image_path = path or os.path.join(userge.Config.DOWN_PATH, f"{basename(video_file)}.jpg")
-    command = f"ffmpeg -ss {ttl} -i '{video_file}' -vframes 1 '{thumb_image_path}'"
+    command = f'''ffmpeg -ss {ttl} -i "{video_file}" -vframes 1 "{thumb_image_path}"'''
     err = (await runcmd(command))[1]
     if err:
         _LOG.error(err)


### PR DESCRIPTION
This will fix this https://nekobin.com/sayufenose error.

It is caused by the use of apostrophe + s ('s) in  the file name. 
You can reproduce this error by making a directory like `Newton's law of motion/lect1.mp4` . And after giving upload command.

(It will give you error while taking screenshot for lect1.mp4)