### PR TITLE
Fix for breaking update from pyro

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ oauth2client
 Pillow==7.1.0
 psutil
 pybase64
-pyrogram>=1.0.7
+pyrogram==1.0.7
 pySmartDL
 python-dotenv
 pytz


### PR DESCRIPTION
Well pyro pushed their latest release with some breaking updates where firstly they replaced or omitted file_ref with file_unique_id and can say "integrated file_ref to file_id for bot api compatibility" , So better to downgrade till further actions