### PR TITLE
Support for adding private repositories as custom plugins repo

### DIFF
--- a/init/checks.sh
+++ b/init/checks.sh
@@ -195,7 +195,7 @@ _checkUnoffPlugins() {
 }
 
 _checkCustomPlugins() {
-    _setupPlugins Custom https://github.com/.+/.+ $CUSTOM_PLUGINS_REPO
+    _setupPlugins Custom https://([0-9a-f]{40}@)?github.com/.+/.+ $CUSTOM_PLUGINS_REPO
 }
 
 assertPrerequisites() {


### PR DESCRIPTION
Now users can add their private repositories in the form

https://<personal_access_token>@github.com/username/repo

More about using/creating personal access tokens
https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
https://stackoverflow.com/a/66156992/5659132
