### PR TITLE
Dockerfile: Change base to python slim-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 # set base image (host OS)
-FROM python:3.9
+FROM python:3.9-slim-buster
 
 # set the working directory in the container
 WORKDIR /app/
 
-RUN apt -qq update
+RUN echo deb http://http.us.debian.org/debian/ testing non-free contrib main > /etc/apt/sources.list && \
+    apt -qq update
 RUN apt -qq install -y --no-install-recommends \
     curl \
     git \
+    gcc \
+    g++ \
+    build-essential \ 
     gnupg2 \
     unzip \
     wget \
@@ -55,3 +59,4 @@ COPY . .
 
 # command to run on container start
 CMD [ "bash", "./run" ]
+.


### PR DESCRIPTION
because using python3 is a fat image.
using python3 slim buster will make slimming image
and this will fix the modules that need ffmpeg 4.3 or above version

`If the user finds a problem with this image, please feel free to give feedback thanks :)`