### PR TITLE
Cannot Install Google Chrome.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt -qq install -y --no-install-recommends \
     unzip \
     wget \
     ffmpeg \
+    libgconf2-4 \
+    libnss3-1d \
+    libxss1 \
     jq
 
 # install chrome


### PR DESCRIPTION
Error: google-chrome-stable 81.0.4044.138-1_amd64.deb dpkg-deb