### PR TITLE
fix locks

### DIFF
--- a/userge/plugins/admin/locks.py
+++ b/userge/plugins/admin/locks.py
@@ -21,10 +21,8 @@ from userge import userge, Message
 
 CHANNEL = userge.getCLogger(__name__)
 
-_types = [
-    'msg', 'media', 'polls', 'invite', 'pin', 'info',
-    'webprev', 'inlinebots', 'animations', 'games', 'stickers'
-]
+_types = ('msg', 'media', 'polls', 'invite', 'pin', 'info', 'webprev',
+          'inlinebots', 'animations', 'games', 'stickers')
 
 
 async def _get_banned_rights(message: Message) -> ChatBannedRights:
@@ -33,10 +31,9 @@ async def _get_banned_rights(message: Message) -> ChatBannedRights:
         return (await message.client.send(
             GetFullChannel(
                 channel=peer))).chats[0].default_banned_rights
-    else:
-        return (await message.client.send(
-            GetFullChat(
-                chat_id=peer.chat_id))).chats[0].default_banned_rights
+    return (await message.client.send(
+        GetFullChat(
+            chat_id=peer.chat_id))).chats[0].default_banned_rights
 
 
 async def _get_new_rights(message: Message, lock_type: str,

--- a/userge/plugins/admin/locks.py
+++ b/userge/plugins/admin/locks.py
@@ -13,7 +13,7 @@ from typing import Tuple, Optional
 
 from pyrogram.types import ChatPermissions
 from pyrogram.errors import ChatNotModified
-from pyrogram.raw.types import InputChannel, ChatBannedRights
+from pyrogram.raw.types import InputPeerChannel, ChatBannedRights
 from pyrogram.raw.functions.channels import GetFullChannel
 from pyrogram.raw.functions.messages import GetFullChat, EditChatDefaultBannedRights
 
@@ -27,7 +27,7 @@ _types = ('msg', 'media', 'polls', 'invite', 'pin', 'info', 'webprev',
 
 async def _get_banned_rights(message: Message) -> ChatBannedRights:
     peer = await message.client.resolve_peer(message.chat.id)
-    if isinstance(peer, InputChannel):
+    if isinstance(peer, InputPeerChannel):
         return (await message.client.send(
             GetFullChannel(
                 channel=peer))).chats[0].default_banned_rights

--- a/userge/plugins/admin/locks.py
+++ b/userge/plugins/admin/locks.py
@@ -27,7 +27,8 @@ _types = [
 ]
 
 
-def _get_chat_lock(permissions: ChatBannedRights, lock_type: str, should_lock: bool) -> Sequence[str]:
+def _get_chat_lock(permissions: ChatBannedRights, lock_type: str,
+                   should_lock: bool) -> Sequence[str]:
     lock = not should_lock
     msg = not permissions.send_messages
     media = not permissions.send_media
@@ -197,7 +198,9 @@ async def unlock_perm(message: Message):
                 f"#UNLOCK\n\nCHAT: `{message.chat.title}` (`{chat_id}`)\n"
                 f"PERMISSIONS: `All Permissions`")
         except ChatNotModified:
-            await message.edit("Nothing was changed, since currently no locks are applied here.", del_in=5)
+            await message.edit(
+                "Nothing was changed, since currently no locks are applied here.",
+                del_in=5)
         except Exception as e_f:
             await message.edit(
                 r"`i don't have permission to do that ＞︿＜`\n\n"
@@ -268,7 +271,7 @@ async def view_perm(message: Message):
     (vmsg, vmedia, vstickers,
      vanimations, vgames, vinlinebots,
      vwebprev, vpolls, vinfo, vinvite,
-     vpin, vperm) = _get_chat_lock(chat_perm, "_", False)
+     vpin, _) = _get_chat_lock(chat_perm, "_", False)
 
     def convert_to_emoji(val: bool):
         return "✅" if val else "❌"


### PR DESCRIPTION
Pyrogram replaced `can_send_stickers`, `can_send_animations`, `can_send_games` and `can_use_inline_bots` with `can_send_other_messages` from 1.2.11 onwards. This means we cant anymore restrict / allow sending stickers, animations, games and inline bot results individually.  All the four is now merged to `can_send_other_messages`.

This commit will re-enable those api locks using pyrogram raw methords and make it possible to use the existing locks available in userge.