### PR TITLE
Added new "Info" button for bot pm

### DIFF
--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -162,7 +162,8 @@ if userge.has_bot:
                 reply_markup=mp
             )
         elif cq.data == "close":
-            await cq.delete()
+            await msg.delete()
+
         await send_start_text(msg, text, path, markup)
 
     @bot.on_message(
@@ -184,7 +185,7 @@ if userge.has_bot:
 
     @bot.on_message(
         filters.user(userge_id) & filters.private & filters.command("setinfo"), group=1)
-    async def set_text(_, msg: PyroMessage):
+    async def set_info(_, msg: PyroMessage):
         global INFO_TEXT  # pylint: disable=global-statement
         text = msg.text.split(' ', maxsplit=1)[1] if ' ' in msg.text else ''
         replied = msg.reply_to_message
@@ -311,8 +312,7 @@ After Adding a var, you can see your media when you start your Bot.
 
     @bot.on_callback_query(
         filters.regex(
-        "startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|en_dis_bot_pm")
-    )
+        "startcq|stngs|bothelp|misc|setmedia|settext|setinfo|broadcast|stats|en_dis_bot_pm"))
     async def cq_handler(_, cq: CallbackQuery):
         global BOT_PM, IN_CONVO  # pylint: disable=global-statement
         settings_markup = InlineKeyboardMarkup(

--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -46,7 +46,7 @@ _STATS: Dict[str, int] = {"incoming": 0, "outgoing": 0}
 START_TEXT = " Hello {mention}, you can contact me using this Bot."
 START_MEDIA = os.environ.get("START_MEDIA")
 INFO_TEXT = " Hello {mention}, this is a bot just for feedback./n"
-            f"You can just contact me using this bot."
+            "You can just contact me using this bot."
 
 botPmFilter = filters.create(lambda _, __, ___: BOT_PM)
 bannedFilter = filters.create(lambda _, __, ___: ___.chat.id in _BANNED_USERS)
@@ -312,7 +312,8 @@ After Adding a var, you can see your media when you start your Bot.
 """
 
     @bot.on_callback_query(
-        filters.regex("startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|en_dis_bot_pm")
+        filters.regex("startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|
+                      en_dis_bot_pm")
     )
     async def cq_handler(_, cq: CallbackQuery):
         global BOT_PM, IN_CONVO  # pylint: disable=global-statement

--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -45,8 +45,7 @@ _STATS: Dict[str, int] = {"incoming": 0, "outgoing": 0}
 
 START_TEXT = " Hello {mention}, you can contact me using this Bot."
 START_MEDIA = os.environ.get("START_MEDIA")
-INFO_TEXT = " Hello {mention}, this is a bot just for feedback./n"
-            "You can just contact me using this bot."
+INFO_TEXT = " Hello {mention}, this is a bot just for feedback./n You can just contact me using this bot."
 
 botPmFilter = filters.create(lambda _, __, ___: BOT_PM)
 bannedFilter = filters.create(lambda _, __, ___: ___.chat.id in _BANNED_USERS)
@@ -312,8 +311,7 @@ After Adding a var, you can see your media when you start your Bot.
 """
 
     @bot.on_callback_query(
-        filters.regex("startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|
-                      en_dis_bot_pm")
+     filters.regex("startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|en_dis_bot_pm")
     )
     async def cq_handler(_, cq: CallbackQuery):
         global BOT_PM, IN_CONVO  # pylint: disable=global-statement

--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -102,7 +102,7 @@ if userge.has_bot:
 
     @bot.on_message(
         ~bannedFilter & ~filters.edited & filters.private & filters.command("start"), group=1)
-    async def start(_, msg: PyroMessage):
+    async def start(_, msg: PyroMessage, cq: CallbackQuery):
         user_id = msg.from_user.id
         user_dict = await bot.get_user_dict(user_id)
         text = START_TEXT.format_map(SafeDict(**user_dict))
@@ -311,7 +311,8 @@ After Adding a var, you can see your media when you start your Bot.
 """
 
     @bot.on_callback_query(
-     filters.regex("startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|en_dis_bot_pm")
+        filters.regex(
+        "startcq|stngs|bothelp|misc|setmedia|settext|info|broadcast|stats|en_dis_bot_pm")
     )
     async def cq_handler(_, cq: CallbackQuery):
         global BOT_PM, IN_CONVO  # pylint: disable=global-statement

--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -45,7 +45,8 @@ _STATS: Dict[str, int] = {"incoming": 0, "outgoing": 0}
 
 START_TEXT = " Hello {mention}, you can contact me using this Bot."
 START_MEDIA = os.environ.get("START_MEDIA")
-INFO_TEXT = " Hello {mention}, this is a bot just for feedback./n You can just contact me using this bot."
+INFO_TEXT = """ Hello {mention}, this is a bot just for feedback./n
+               You can just contact me using this bot."""
 
 botPmFilter = filters.create(lambda _, __, ___: BOT_PM)
 bannedFilter = filters.create(lambda _, __, ___: ___.chat.id in _BANNED_USERS)
@@ -145,8 +146,6 @@ if userge.has_bot:
             else:
                 out_str = f"<i>No Command Found for</i>: <code>{cmd}</code>"
             return await msg.reply(out_str, parse_mode='html', disable_web_page_preview=True)
-        await send_start_text(msg, text, path, markup)
-
         elif cq.data == "info":
             copy_ = "https://github.com/UsergeTeam/Userge/blob/master/LICENSE"
             mp = InlineKeyboardMarkup([
@@ -162,9 +161,9 @@ if userge.has_bot:
                 disable_web_page_preview=True,
                 reply_markup=mp
             )
-
         elif cq.data == "close":
             await cq.delete()
+        await send_start_text(msg, text, path, markup)
 
     @bot.on_message(
         filters.user(userge_id) & filters.private & filters.command("settext"), group=1)

--- a/userge/plugins/utils/botpm.py
+++ b/userge/plugins/utils/botpm.py
@@ -133,6 +133,7 @@ if userge.has_bot:
         text = "Hey, you can configure me here."
         markup = InlineKeyboardMarkup([[InlineKeyboardButton("Settings", callback_data="stngs")]])
         cmd = msg.command[1] if len(msg.command) > 1 else ''
+
         if cmd and ' ' not in msg.text:
             commands = userge.manager.enabled_commands
             key = Config.CMD_TRIGGER + cmd
@@ -311,8 +312,8 @@ After Adding a var, you can see your media when you start your Bot.
 """
 
     @bot.on_callback_query(
-        filters.regex(
-        "startcq|stngs|bothelp|misc|setmedia|settext|setinfo|broadcast|stats|en_dis_bot_pm"))
+        filters.regex("""startcq|stngs|bothelp|misc|setmedia|settext|setinfo|
+                      broadcast|stats|en_dis_bot_pm"""))
     async def cq_handler(_, cq: CallbackQuery):
         global BOT_PM, IN_CONVO  # pylint: disable=global-statement
         settings_markup = InlineKeyboardMarkup(


### PR DESCRIPTION
Added a new button called "Info" in botpm.
Added some features and commands for the success of this.
Moved "UsergeTeam", "Repo" and "License" buttons to the info menu.
## Why this...
The button "Info" can be used to show a specific text to those who've started the bot.
`INFO_TEXT` which is used to show this info, can be changed at anytime using `/setinfo` command.