### PR TITLE
Optimising regex with special char detection

### DIFF
--- a/userge/core/types/bound/message.py
+++ b/userge/core/types/bound/message.py
@@ -160,7 +160,7 @@ class Message(RawMessage):
 
         if input_str.startswith(prefix):
             del_pre = bool(self._kwargs.get('del_pre', False))
-            pattern = re.compile(f"({prefix}[A-z]+)(\\d*|=\\w*)$")
+            pattern = re.compile(rf"({prefix}[A-z]+)(=?\S*)$")
 
             end = False
             parts = input_str.split(' ')


### PR DESCRIPTION
I didn't checked the worst cases where it breaks but flags like -at=-100xxxxxxxxx works fine now without breaking previous detections
@rking32 maybe i need your review