### PR TITLE
[paste] Fixed key path according to new response schema

### DIFF
--- a/userge/plugins/utils/paste.py
+++ b/userge/plugins/utils/paste.py
@@ -120,13 +120,16 @@ class Pasting(PasteService):
 
     async def paste(self, ses: aiohttp.ClientSession,
                     text: str, file_type: Optional[str]) -> Optional[str]:
-        data = {"content": text}
+        data = {
+            "heading": "userge",
+            "content": text
+        }
         if file_type:
             data['code'] = "true"
         async with ses.post(self._url + "api", json=data) as resp:
             if resp.status != 200:
                 return None
-            return self._url + await resp.text()
+            return self._url + await resp.josn()['key']
 
 
 class PastyLus(PasteService):

--- a/userge/plugins/utils/paste.py
+++ b/userge/plugins/utils/paste.py
@@ -129,7 +129,7 @@ class Pasting(PasteService):
         async with ses.post(self._url + "api", json=data) as resp:
             if resp.status != 200:
                 return None
-            return self._url + await resp.json()['key']
+            return self._url + (await resp.json())['key']
 
 
 class PastyLus(PasteService):

--- a/userge/plugins/utils/paste.py
+++ b/userge/plugins/utils/paste.py
@@ -129,7 +129,7 @@ class Pasting(PasteService):
         async with ses.post(self._url + "api", json=data) as resp:
             if resp.status != 200:
                 return None
-            return self._url + await resp.josn()['key']
+            return self._url + await resp.json()['key']
 
 
 class PastyLus(PasteService):


### PR DESCRIPTION
Recently https://pasting.ga updated their API which returns the key in JSON format.

- Response before
```
Ufbto5NU
```

- Response now
```json
{
  "key": "Ufbto5NU",
  "url": "http://zsrs08.deta.dev/Ufbto5NU"
}
```