### PR TITLE
Use random User-Agent in `webss.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ covid
 cowpy
 dnspython
 emoji==0.6.0
+fake-headers
 feedparser
 ffmpeg-python
 gitpython

--- a/userge/plugins/utils/webss.py
+++ b/userge/plugins/utils/webss.py
@@ -12,7 +12,7 @@ from re import match
 
 import aiofiles
 from selenium import webdriver
-
+from fake_headers import Headers
 from userge import userge, Message, Config
 
 
@@ -28,6 +28,7 @@ async def webss(message: Message):
     link = link_match.group()
     await message.edit("`Processing ...`")
     chrome_options = webdriver.ChromeOptions()
+    header = Headers(headers=False).generate()
     chrome_options.binary_location = Config.GOOGLE_CHROME_BIN
     chrome_options.add_argument('--ignore-certificate-errors')
     chrome_options.add_argument("--test-type")
@@ -36,6 +37,7 @@ async def webss(message: Message):
     chrome_options.add_argument('--disable-dev-shm-usage')
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument('--disable-gpu')
+    chrome_options.add_argument(f"user-agent={header['User-Agent']}")
     driver = webdriver.Chrome(chrome_options=chrome_options)
     driver.get(link)
     height = driver.execute_script(


### PR DESCRIPTION
In headless chrome mode, the user agent is something like this: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/60.0.3112.50 Safari/537.36

The service provider updated their code to identify the HeadlessChrome part and would cause the tab to crash and in turn, destroying the Selenium user session.

This can bypass that User-Agent blocking and generate screenshot.