### PR TITLE
Removed hide_via parameter

### DIFF
--- a/userge/core/types/bound/message.py
+++ b/userge/core/types/bound/message.py
@@ -633,7 +633,7 @@ class Message(RawMessage):
                 await self.delete()
                 msg_obj = await self._client.send_inline_bot_result(
                     self.chat.id, query_id=k.query_id,
-                    result_id=k.results[2].id, hide_via=True
+                    result_id=k.results[2].id
                 )
             except (IndexError, BotInlineDisabled):
                 del_in = del_in if del_in > 0 else _ERROR_MSG_DELETE_TIMEOUT
@@ -746,7 +746,7 @@ class Message(RawMessage):
                     await self.delete()
                     msg_obj = await self._client.send_inline_bot_result(
                         self.chat.id, query_id=k.query_id,
-                        result_id=k.results[2].id, hide_via=True
+                        result_id=k.results[2].id
                     )
                 except (IndexError, BotInlineDisabled):
                     del_in = del_in if del_in > 0 else _ERROR_MSG_DELETE_TIMEOUT

--- a/userge/plugins/builtin/help/__main__.py
+++ b/userge/plugins/builtin/help/__main__.py
@@ -56,8 +56,7 @@ async def helpme(message: Message) -> None:  # pylint: disable=missing-function-
         await userge.send_inline_bot_result(
             chat_id=message.chat.id,
             query_id=menu.query_id,
-            result_id=menu.results[1].id,
-            hide_via=True)
+            result_id=menu.results[1].id)
         return await message.delete()
 
     if not message.input_str:


### PR DESCRIPTION
Removed `hide_via` parameter from [send_inline_bot_result](https://github.com/pyrogram/pyrogram/commit/0c0a4b5a5c8f20a0df9dcea843271d3ab0009c68) functions.