### PR TITLE
Fix Dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dnspython
+dnspython==2.3.0
 heroku3
 motor
 pyrogram==2.0.58


### PR DESCRIPTION
FIX: Telegram updates something so that the old pyrogram version no longer works
FIX: dnspython latest version error, so i set oldversion in requimenets.txt

TESTING:
Tested in linux [ ubuntu 22.04, windows 11, docker ]
