### PR TITLE
Fix dependency error and update Pyrogram version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dnspython
+dnspython==2.3.0
 heroku3
 motor
-pyrogram==2.0.58
+pyrogram==2.0.106
 tgcrypto


### PR DESCRIPTION
FIX: dnspython error in latest version
FIX: Telegram updates something so that the old pyrogram version no longer works